### PR TITLE
Enable building with x on linux

### DIFF
--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -7,5 +7,10 @@ sed -i -- "s|@prefix@|${PREFIX}|g" sdl2-config.in
 
 # Build SDL2
 ./autogen.sh
-./configure --prefix=${PREFIX} --disable-haptic --without-x
+if [ -z ${OSX_ARCH+x} ]; then
+  ./configure --prefix=${PREFIX} --disable-haptic --without-x;
+else
+  ./configure --prefix=${PREFIX} --disable-haptic;
+fi
+
 make install

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -8,9 +8,9 @@ sed -i -- "s|@prefix@|${PREFIX}|g" sdl2-config.in
 # Build SDL2
 ./autogen.sh
 if [ -z ${OSX_ARCH+x} ]; then
-  ./configure --prefix=${PREFIX} --disable-haptic --without-x;
-else
   ./configure --prefix=${PREFIX} --disable-haptic;
+else
+  ./configure --prefix=${PREFIX} --disable-haptic --without-x;
 fi
 
 make install

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -27,6 +27,7 @@ requirements:
     - vc 14  # [win and py35]
     - cmake  # [win]
     - autoconf  # [unix]
+    - xorg-libx11 # [linux]
   run:
     - vc 9  # [win and py27]
     - vc 10  # [win and py34]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -27,7 +27,7 @@ requirements:
     - vc 14  # [win and py35]
     - cmake  # [win]
     - autoconf  # [unix]
-    - xorg-libx11 # [linux]
+    - xorg-libx11  # [linux]
   run:
     - vc 9  # [win and py27]
     - vc 10  # [win and py34]


### PR DESCRIPTION
I ran into issues trying to use sdl2 with a gui application (kivy) on ubuntu, which didn't work because sdl2 was built without x support. This adds x support for the build.